### PR TITLE
fix: repeated linux kernel OOM killer invocations while finetuning

### DIFF
--- a/finetuning_repo/ds_config_gptj6b.json
+++ b/finetuning_repo/ds_config_gptj6b.json
@@ -28,11 +28,11 @@
         "stage": 3,
         "offload_optimizer": {
             "device": "cpu",
-            "pin_memory": true
+            "pin_memory": false
         },
         "offload_param": {
             "device": "cpu",
-            "pin_memory": true
+            "pin_memory": false
         },
         "overlap_comm": true,
         "contiguous_gradients": true,


### PR DESCRIPTION
This change allows the operating system to take the optimizer memory to swap when there is memory pressure. This prevents some OOM invocations and lets finetuning continue with the downside that the system may become unresponsive while the kernel manages allocation of available memory.

⚠️⚠️⚠️  If your swapfile is on a SSD/NVMe and the system starts thrashing it, because your system RAM is too low, the lifespan of your hardware will take a hit.

@mallorbc After applying #4 I've not been able to save any finetuned checkpoints without getting killed by the kernel OOM. With pin_memory set to false, I've been able to save chackpoints and can confirm that inference works correctly on them.