### PR TITLE
Update trl_finetune.py

### DIFF
--- a/finetuning_repo/trl_finetune.py
+++ b/finetuning_repo/trl_finetune.py
@@ -80,7 +80,7 @@ if __name__ == "__main__":
         logger.info("Model is not llama, disabling flash attention...")
     elif args.disable_flash_attention and model_type == "llama":
         logger.info("Model is llama, could be using flash attention...")
-    elif not args.disable_flash_attention and torch.cuda.get_device_capability()[0] >= 8:
+    if not args.disable_flash_attention and torch.cuda.get_device_capability()[0] >= 8:
         from llama_patch import replace_attn_with_flash_attn
         logger.info("Using flash attention...")
         replace_attn_with_flash_attn()


### PR DESCRIPTION
I have tried to utilize trl_finetune.py to finetune the GPT-J, but it raised the following error:

> Traceback (most recent call last):
  File "trl_finetune.py", line 151, in <module>
    if use_flash_attention:
NameError: name 'use_flash_attention' is not defined

with this run script:`accelerate launch trl_finetune.py --block_size 1024 --eval_steps 100 --save_steps 100 -tf train.csv -vf validation.csv -m meta-llama/Llama-2-7b-hf -b 1 --log_steps 100 -lr 2e-4 -e 1 --gradient_accumulation_steps 16 --pad_token_id=18636`

I found there may be a tiny error in trl_finetune.py at line 83, where the "elif" should be modified to "if" to make sense.
Otherwise, it will raise an error when using this script to finetune LLM except LIama.
From my perspective, the above modification seems reasonable, and the revised version seems to work well. But im a freshman in the area of LLMs, so im not sure that's right. 